### PR TITLE
Newer benchmarks

### DIFF
--- a/cissors.go
+++ b/cissors.go
@@ -2,15 +2,15 @@ package cissors
 
 // Location describes location of the Rule in a CIS benchmark
 type Location struct {
-	ID   string `yaml:"id"`
-	Name string `yaml:"name"`
+	ID   string `yaml:"id" json:"id"`
+	Name string `yaml:"name" json:"name"`
 }
 
 // Rule describes a CIS benchmark rule
 type Rule struct {
-	ID       string            `yaml:"id"`
-	Name     string            `yaml:"name"`
-	Scored   bool              `yaml:"scored"`
-	Location []Location        `yaml:"location,omitempty"`
-	Sections map[string]string `yaml:"-,inline"`
+	ID       string            `yaml:"id" json:"id"`
+	Name     string            `yaml:"name" json:"name"`
+	Scored   bool              `yaml:"scored" json:"scored"`
+	Location []Location        `yaml:"location,omitempty" json:"location,omitempty"`
+	Sections map[string]string `yaml:"-,inline" json:"sections"`
 }

--- a/cissors.go
+++ b/cissors.go
@@ -10,6 +10,7 @@ type Location struct {
 type Rule struct {
 	ID       string            `yaml:"id"`
 	Name     string            `yaml:"name"`
+	Scored   bool              `yaml:"scored"`
 	Location []Location        `yaml:"location,omitempty"`
 	Sections map[string]string `yaml:"-,inline"`
 }

--- a/cmd/cissors/main.go
+++ b/cmd/cissors/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -140,13 +141,19 @@ func main() {
 
 	var output = ""
 	if *format == "json" {
-		jsonData, err := json.MarshalIndent(&rules, "", "    ")
+		buf := new(bytes.Buffer)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+
+		err := enc.Encode(&rules)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to serialize as JSON: %v\n", err)
 			return
 		}
 
-		output = string(jsonData)
+		var out bytes.Buffer
+		json.Indent(&out, buf.Bytes(), "", "    ")
+		output = out.String()
 	} else {
 		yamlData, err := yaml.Marshal(&rules)
 		if err != nil {

--- a/cmd/cissors/main.go
+++ b/cmd/cissors/main.go
@@ -23,14 +23,15 @@ var (
 )
 
 var (
-	pageMarkerRegex = regexp.MustCompile(`^([\d]+ \| Page)  `)
+	pageMarkerRegex = regexp.MustCompile(`^([\d]+\s+\|\s+Page)`)
 
 	titleExtractRegex = regexp.MustCompile(`((\d+\.)*?(\d+))\s([A-Za-z]*)(\s[A-Za-z\:\.,_\-\/\(\)]*?|\s\d{1,5}|\s(?:[0-9]{1,3}\.){3}[0-9]{1,3}(\/\d{1,2})?)*(\.+)?\s\d+\s`)
 	titleCropRegex    = regexp.MustCompile(`\s?\.+\s\d+\s$`)
 	titleIDRegex      = regexp.MustCompile(`((\d+\.)*?(\d+))\s`)
+	whitespace        = regexp.MustCompile(`\s+`)
 
 	sectionRegex = regexp.MustCompile(
-		`((Profile Applicability|Description|Rationale|Audit|Remediation|Impact|Default Value|References|CIS Controls)\:\s)`,
+		`((Profile Applicability|Description|Rationale|Audit|Remediation|Impact|Default\sValue|References|CIS\sControls)\:\s+)`,
 	)
 
 	ruleTitleExtractRegex = regexp.MustCompile(`((\d+\.)*?(\d+))\s([A-Za-z]*)(\s[A-Za-z\:\.,_\-\/\(\)]*?|\d{1,5}|(?:[0-9]{1,3}\.){3}[0-9]{1,3}(\/\d{1,2})?)*\((Not\s)?Scored\)`)
@@ -236,7 +237,7 @@ func splitTitle(title string) (id, name string, err error) {
 	}
 
 	id = title[idxID[0] : idxID[1]-1]
-	name = title[idxID[1]:]
+	name = replaceWhitespaces(title[idxID[1]:])
 	return
 }
 
@@ -269,13 +270,17 @@ func findNamedValuesByRegex(s string, r *regexp.Regexp) []namedValue {
 }
 
 func sectionKeyName(name string) string {
-	key := strings.ToLower(strings.Trim(name, " :"))
-	return strings.ReplaceAll(key, " ", "_")
+	key := strings.ToLower(strings.Trim(name, " :\t\n"))
+	return whitespace.ReplaceAllString(key, "_")
 }
 
 func sectionContent(content string) string {
 	content = strings.TrimSpace(nonASCIIRegex.ReplaceAllLiteralString(content, ""))
-	return strings.ReplaceAll(content, "  ", " ")
+	return replaceWhitespaces(content)
+}
+
+func replaceWhitespaces(content string) string {
+	return whitespace.ReplaceAllString(content, " ")
 }
 
 func getRuleLocation(ruleIDToName map[string]string, ruleID string) []cissors.Location {


### PR DESCRIPTION
This tool works well! A few changes:
- Allow to export as JSON instead of YAML
- Add scored as a property of a rule
- Fix parsing for the newest benchmark (1.5.1), where the use of \t was messing things up.